### PR TITLE
stringify PK

### DIFF
--- a/leaflet_admin_list/admin.py
+++ b/leaflet_admin_list/admin.py
@@ -98,7 +98,7 @@ class LeafletAdminListMixin(object):
             'field': name,
             'app_label': o._meta.app_label,
             'model_name': o._meta.model_name,
-            'pk': o.pk,
+            'pk': str(o.pk),
         }
         popup = self.get_geojson_feature_popup(request, name, o, queryset)
         tooltip = self.get_geojson_feature_tooltip(request, name, o, queryset)


### PR DESCRIPTION
This is presumptuous, but for those of us who use the https://github.com/nshafer/django-hashid-field it would be useful to stringify the PK.   Without this, the library throws a serialization error.